### PR TITLE
bugfix/Refresh-rates-continues-in-background

### DIFF
--- a/app/src/main/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesListFragment.kt
+++ b/app/src/main/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesListFragment.kt
@@ -55,11 +55,13 @@ class RatesListFragment : DaggerFragment(), RatesAdapter.RateAdapterListener {
     override fun onResume() {
         super.onResume()
         observeNoFocusedAmountField()
+        viewModel.toggleRefreshRatesInterval(true)
     }
 
     override fun onPause() {
         super.onPause()
         compositeDisposable.clear()
+        viewModel.toggleRefreshRatesInterval(false)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesViewModel.kt
+++ b/app/src/main/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesViewModel.kt
@@ -44,10 +44,6 @@ class RatesViewModel(
     }
 
     fun getResult(): LiveData<UIRateResource> {
-        // Only if we have a subscriber we wan't to start the interval.
-        if (compositeDisposable.size() == 0)
-            startFetchingRatesInterval()
-
         return result
     }
 
@@ -64,6 +60,13 @@ class RatesViewModel(
                 content = uiRateUtil.moveToTopOfList(fromIndex, result.value?.content)
             )
         }
+    }
+
+    fun toggleRefreshRatesInterval(isStart: Boolean) {
+        if (isStart)
+            startFetchingRatesInterval()
+        else
+            compositeDisposable.clear()
     }
 
     private fun startFetchingRatesInterval() {
@@ -88,6 +91,7 @@ class RatesViewModel(
                     }
                 }
         }
+        compositeDisposable.clear()
         compositeDisposable.add(disposable)
     }
 

--- a/app/src/test/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesViewModelTest.kt
+++ b/app/src/test/java/com/ronybrosh/revolutandroidtest/presentation/features/rates/view/RatesViewModelTest.kt
@@ -105,6 +105,7 @@ class RatesViewModelTest {
 
         // Act
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
         latch.await(5, TimeUnit.SECONDS)
 
         // Assert
@@ -133,6 +134,7 @@ class RatesViewModelTest {
         // Act
         viewModel.getLoading().observeForever(loadingObserver)
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
 
         // Assert
         inOrder.verify(loadingObserver, times(2)).onChanged(loadingCaptor.capture())
@@ -162,6 +164,7 @@ class RatesViewModelTest {
 
         // Act
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
 
         // Assert
         verify(uiRateListObserver).onChanged(uiRateListCaptor.capture())
@@ -181,6 +184,7 @@ class RatesViewModelTest {
         // Act
         viewModel.getError().observeForever(errorObserver)
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
 
         // Assert
         verify(errorObserver).onChanged(errorCaptor.capture())
@@ -213,6 +217,7 @@ class RatesViewModelTest {
 
         // Act
         val liveData = viewModel.getResult()
+        viewModel.toggleRefreshRatesInterval(true)
         liveData.observeForever(uiRateListObserver)
         latch.await(1500, TimeUnit.MILLISECONDS)
 
@@ -274,6 +279,7 @@ class RatesViewModelTest {
 
         // Act
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
         viewModel.updateRatesConversion("2", 1F)
 
         // Assert
@@ -321,6 +327,7 @@ class RatesViewModelTest {
 
         // Act
         viewModel.getResult().observeForever(uiRateListObserver)
+        viewModel.toggleRefreshRatesInterval(true)
         viewModel.moveToTopOfList(lastItemIndex)
 
         // Assert


### PR DESCRIPTION
1. Added toggle refresh rates interval to rates view model to pause and resume the service
2. Fixed unit tests

